### PR TITLE
Add floating major.minor and latest Docker tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,32 @@ jobs:
         - name: Configure Namespace powered Buildx
           uses: namespacelabs/nscloud-setup-buildx-action@v0
 
+        - name: Build tags
+          id: tags
+          env:
+            PATCH_VERSION: ${{ matrix.minorShopwareVersion }}
+            MINOR_VERSION: ${{ matrix.majorMinorShopwareVersion }}
+            IS_LATEST_MINOR: ${{ matrix.isLatestMinor }}
+            IS_LATEST: ${{ matrix.isLatest }}
+          run: |
+            {
+              echo 'tags<<EOF'
+              echo "ghcr.io/friendsofshopware/shopware-demo-environment:${PATCH_VERSION}"
+              echo "friendsofshopware/shopware-demo-environment:${PATCH_VERSION}"
+              if [ "$IS_LATEST_MINOR" = "true" ]; then
+                echo "ghcr.io/friendsofshopware/shopware-demo-environment:${MINOR_VERSION}"
+                echo "friendsofshopware/shopware-demo-environment:${MINOR_VERSION}"
+              fi
+              if [ "$IS_LATEST" = "true" ]; then
+                echo "ghcr.io/friendsofshopware/shopware-demo-environment:latest"
+                echo "friendsofshopware/shopware-demo-environment:latest"
+              fi
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+
         - uses: docker/build-push-action@v7
           with:
-            tags: |
-              ghcr.io/friendsofshopware/shopware-demo-environment:${{ matrix.minorShopwareVersion }}
-              friendsofshopware/shopware-demo-environment:${{ matrix.minorShopwareVersion }}
+            tags: ${{ steps.tags.outputs.tags }}
             platforms: linux/amd64,linux/arm64
             build-args: |
               PHP_VERSION=${{ matrix.phpVersion }}

--- a/matrix.js
+++ b/matrix.js
@@ -31,11 +31,13 @@ async function getMatrix() {
             .map(([key, value]) => {
                 const versionSplit = key.split('.');
                 const version = [versionSplit[0], versionSplit[1], versionSplit[2]].join('.');
-                
+                const majorMinor = [versionSplit[0], versionSplit[1]].join('.');
+
                 return {
                     phpVersion: value,
                     shopwareVersion: key.toLowerCase(),
-                    minorShopwareVersion: version
+                    minorShopwareVersion: version,
+                    majorMinorShopwareVersion: majorMinor
                 };
             })
             .reverse()
@@ -61,6 +63,35 @@ async function getMatrix() {
             
             return acc;
         }, []);
+
+        // Sort newest-first by semantic version so the latest patch is reliably
+        // first within each major.minor group (source order is not numeric-aware,
+        // e.g. it can place 6.7.9 after 6.7.10).
+        uniqueVersions.sort((a, b) => {
+            const aParts = a.minorShopwareVersion.split('.').map(Number);
+            const bParts = b.minorShopwareVersion.split('.').map(Number);
+
+            for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+                const diff = (bParts[i] || 0) - (aParts[i] || 0);
+                if (diff !== 0) return diff;
+            }
+            return 0;
+        });
+
+        // Mark the latest patch within each major.minor group so it also gets
+        // a floating major.minor tag (e.g. 6.7, 6.6). uniqueVersions is ordered
+        // newest-first, so the first entry seen per group is the latest patch,
+        // and the very first entry overall is the latest version (gets `latest`).
+        const seenMajorMinor = new Set();
+        uniqueVersions.forEach((item, index) => {
+            if (!seenMajorMinor.has(item.majorMinorShopwareVersion)) {
+                seenMajorMinor.add(item.majorMinorShopwareVersion);
+                item.isLatestMinor = true;
+            } else {
+                item.isLatestMinor = false;
+            }
+            item.isLatest = index === 0;
+        });
 
         data.matrix.include = uniqueVersions;
 


### PR DESCRIPTION
The latest patch of each major.minor line now also publishes a floating tag (e.g. 6.7, 6.6), and the newest version overall publishes latest.