### PR TITLE
Add support for FOS Packagist token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ docker run \
     ghcr.io/friendsofshopware/shopware-demo-environment:6.5.8
 ```
 
+For plugins hosted on [packages.fos.gg](https://packages.fos.gg), pass the `FOS_PACKAGIST_TOKEN` environment variable.
+
+Example:
+
+```bash
+docker run \
+    --rm \
+    -e APP_URL=http://localhost:8000 \
+    -e EXTENSIONS="..." \
+    -e FOS_PACKAGIST_TOKEN=your-token \
+    -p 8000:8000 \
+    ghcr.io/friendsofshopware/shopware-demo-environment:6.5.8
+```
+
 ## Running multiple containers
 
 If you want to run multiple containers, you should deploy a Traefik before the containers. This will allow you to access the containers via different subdomains.

--- a/rootfs/entrypoint
+++ b/rootfs/entrypoint
@@ -30,6 +30,11 @@ if [[  ! -z "$EXTENSIONS" ]]; then
         composer config bearer.packages.shopware.com "$SHOPWARE_PACKAGIST_TOKEN"
     fi
 
+    if [[ ! -z "$FOS_PACKAGIST_TOKEN" ]]; then
+        composer config repositories.fos-packages '{"type": "composer", "url": "https://packages.fos.gg"}'
+        composer config bearer.packages.fos.gg "$FOS_PACKAGIST_TOKEN"
+    fi
+
     composer req $EXTENSIONS
 
     php bin/console plugin:refresh


### PR DESCRIPTION
## Summary
This change adds support for authenticating with the Friends of Shopware (FOS) Packagist repository by introducing a new `FOS_PACKAGIST_TOKEN` environment variable.

## Key Changes
- **Documentation**: Added example in README.md showing how to pass the `FOS_PACKAGIST_TOKEN` environment variable when running the Docker container
- **Entrypoint Script**: Updated the entrypoint script to configure Composer with FOS Packagist repository credentials when the `FOS_PACKAGIST_TOKEN` environment variable is provided
  - Registers the FOS Packagist repository URL (`https://packages.fos.gg`) with Composer
  - Configures bearer token authentication for the FOS Packagist registry

## Implementation Details
The implementation follows the same pattern as the existing `SHOPWARE_PACKAGIST_TOKEN` handling, allowing users to install plugins hosted on packages.fos.gg by providing their authentication token as an environment variable during container startup.

https://claude.ai/code/session_01A2wdZbSAUVdGjrHgyhfDtm